### PR TITLE
Add support for keypairs generated by the Rust wallet.

### DIFF
--- a/src/libp2p_crypto.erl
+++ b/src/libp2p_crypto.erl
@@ -208,7 +208,20 @@ keys_from_bin(<<NetType:4, ?KEYTYPE_ED25519:4, PrivKey:64/binary, PubKey:32/bina
         secret => {ed25519, PrivKey},
         public => {ed25519, PubKey},
         network => to_network(NetType)
-    }.
+    };
+
+%% Support the Helium Rust wallet format, which unfortunately duplicates the network
+%% and key type just before the public key.
+keys_from_bin(
+    <<NetType:4, ?KEYTYPE_ECC_COMPACT:4, PrivKey:32/binary,
+        NetType:4, ?KEYTYPE_ECC_COMPACT:4, PubKey:32/binary>>
+) ->
+    keys_from_bin(<<NetType:4, ?KEYTYPE_ED25519:4, PrivKey, PubKey>>);
+keys_from_bin(
+    <<NetType:4, ?KEYTYPE_ED25519:4, PrivKey:64/binary,
+        NetType:4, ?KEYTYPE_ED25519:4, PubKey:32/binary>>
+) ->
+    keys_from_bin(<<NetType:4, ?KEYTYPE_ED25519:4, PrivKey, PubKey>>).
 
 %% @doc Convertsa a given tagged public key to its binary form on the current
 %% network.

--- a/src/libp2p_crypto.erl
+++ b/src/libp2p_crypto.erl
@@ -216,7 +216,7 @@ keys_from_bin(
     <<NetType:4, ?KEYTYPE_ECC_COMPACT:4, PrivKey:32/binary,
         NetType:4, ?KEYTYPE_ECC_COMPACT:4, PubKey:32/binary>>
 ) ->
-    keys_from_bin(<<NetType:4, ?KEYTYPE_ED25519:4, PrivKey, PubKey>>);
+    keys_from_bin(<<NetType:4, ?KEYTYPE_ECC_COMPAT:4, PrivKey, PubKey>>);
 keys_from_bin(
     <<NetType:4, ?KEYTYPE_ED25519:4, PrivKey:64/binary,
         NetType:4, ?KEYTYPE_ED25519:4, PubKey:32/binary>>
@@ -488,6 +488,27 @@ round_trip_short_key_test() ->
     ?assertEqual(ShortKeyMap, keys_from_bin(Bin)),
     ok.
 
+helium_wallet_decode_test() ->
+    FakeTestnetKeyMap = #{
+        secret => {ed25519, <<192, 147, 19, 139, 114, 76, 92, 18, 67, 206, 210, 241, 21,
+            18, 84, 12, 26, 171, 160, 255, 6, 17, 227, 18, 78, 255, 182, 94, 202, 62, 125,
+            50, 75, 192, 49, 183, 242, 203, 231, 180, 84, 235, 178, 8, 57, 34, 132, 195,
+            107, 140, 155, 85, 133, 58, 131, 188, 94, 234, 216, 101, 241, 12, 231, 107>>},
+        public => {ed25519, <<87, 246, 67, 78, 245, 59, 166, 216, 236, 17, 195, 144, 101,
+            96, 188, 112, 178, 183, 80, 75, 195, 218, 46, 184, 175, 181, 131, 207, 236,
+            146, 18, 237>>},
+        network => testnet
+    },
+    FakeTestnetKeyPair = <<17, 192, 147, 19, 139, 114, 76, 92, 18, 67, 206, 210, 241, 21,
+        18, 84, 12, 26, 171, 160, 255, 6, 17, 227, 18, 78, 255, 182, 94, 202, 62, 125, 50,
+        75, 192, 49, 183, 242, 203, 231, 180, 84, 235, 178, 8, 57, 34, 132, 195, 107, 140,
+        155, 85, 133, 58, 131, 188, 94, 234, 216, 101, 241, 12, 231, 107, 17, 87, 246, 67,
+        78, 245, 59, 166, 216, 236, 17, 195, 144, 101, 96, 188, 112, 178, 183, 80, 75, 195,
+        218, 46, 184, 175, 181, 131, 207, 236, 146, 18, 237>>,
+    KeyMap = keys_from_bin(FakeTestnetKeyPair),
+    ?assertEqual(FakeTestnetKeyMap, KeyMap),
+    ok.
+    
 nonl([$\n | T]) -> nonl(T);
 nonl([H | T]) -> [H | nonl(T)];
 nonl([]) -> [].

--- a/src/libp2p_crypto.erl
+++ b/src/libp2p_crypto.erl
@@ -216,12 +216,12 @@ keys_from_bin(
     <<NetType:4, ?KEYTYPE_ECC_COMPACT:4, PrivKey:32/binary,
         NetType:4, ?KEYTYPE_ECC_COMPACT:4, PubKey:32/binary>>
 ) ->
-    keys_from_bin(<<NetType:4, ?KEYTYPE_ECC_COMPAT:4, PrivKey, PubKey>>);
+    keys_from_bin(<<NetType:4, ?KEYTYPE_ECC_COMPACT:4, PrivKey/binary, PubKey/binary>>);
 keys_from_bin(
     <<NetType:4, ?KEYTYPE_ED25519:4, PrivKey:64/binary,
         NetType:4, ?KEYTYPE_ED25519:4, PubKey:32/binary>>
 ) ->
-    keys_from_bin(<<NetType:4, ?KEYTYPE_ED25519:4, PrivKey, PubKey>>).
+    keys_from_bin(<<NetType:4, ?KEYTYPE_ED25519:4, PrivKey/binary, PubKey/binary>>).
 
 %% @doc Convertsa a given tagged public key to its binary form on the current
 %% network.
@@ -499,12 +499,20 @@ helium_wallet_decode_test() ->
             146, 18, 237>>},
         network => testnet
     },
-    FakeTestnetKeyPair = <<17, 192, 147, 19, 139, 114, 76, 92, 18, 67, 206, 210, 241, 21,
-        18, 84, 12, 26, 171, 160, 255, 6, 17, 227, 18, 78, 255, 182, 94, 202, 62, 125, 50,
-        75, 192, 49, 183, 242, 203, 231, 180, 84, 235, 178, 8, 57, 34, 132, 195, 107, 140,
-        155, 85, 133, 58, 131, 188, 94, 234, 216, 101, 241, 12, 231, 107, 17, 87, 246, 67,
-        78, 245, 59, 166, 216, 236, 17, 195, 144, 101, 96, 188, 112, 178, 183, 80, 75, 195,
-        218, 46, 184, 175, 181, 131, 207, 236, 146, 18, 237>>,
+    FakeTestnetKeyPair = <<
+        %% Network/type byte (testnet, EDD25519)
+         17,
+        %% 64-byte private key
+        192, 147,  19, 139, 114,  76,  92,  18,  67, 206, 210, 241,  21,  18,  84,  12,
+         26, 171, 160, 255,   6,  17, 227,  18,  78, 255, 182,  94, 202,  62, 125,  50,
+         75, 192,  49, 183, 242, 203, 231, 180,  84, 235, 178,   8,  57,  34, 132, 195,
+        107, 140, 155,  85, 133,  58, 131, 188,  94, 234, 216, 101, 241,  12, 231, 107,
+        %% Repeated network/type byte
+         17,
+        %% 32-byte public key
+         87, 246,  67,  78, 245,  59, 166, 216, 236,  17, 195, 144, 101,  96, 188, 112,
+        178, 183,  80,  75, 195, 218,  46, 184, 175, 181, 131, 207, 236, 146,  18, 237
+    >>,
     KeyMap = keys_from_bin(FakeTestnetKeyPair),
     ?assertEqual(FakeTestnetKeyMap, KeyMap),
     ok.


### PR DESCRIPTION
The Helium Rust wallet (`helium-wallet-rs`) duplicates the network and key type
byte (also known as the "tag") when encoding the keypair as a binary blob. It
places the tag byte at the begining of the buffer, where it is expected by libp2p,
but it also adds the byte just before the public key, where it is not expected by
libp2p.

This change accomodates the duplication and allows for keys generated by the
wallet to be loaded by libp2p.

This bug was discovered when I tried to load a `helium-wallet-rs`-generated
wallet into `blockchain-node`.