### PR TITLE
Fixes rust wallet ecc_compact key loading

### DIFF
--- a/rebar.lock
+++ b/rebar.lock
@@ -1,6 +1,6 @@
 {"1.1.0",
 [{<<"base32">>,{pkg,<<"base32">>,<<"0.1.0">>},1},
- {<<"ecc_compact">>,{pkg,<<"ecc_compact">>,<<"1.0.4">>},0},
+ {<<"ecc_compact">>,{pkg,<<"ecc_compact">>,<<"1.0.5">>},0},
  {<<"enacl">>,{pkg,<<"enacl">>,<<"1.1.1">>},0},
  {<<"erl_base58">>,{pkg,<<"erl_base58">>,<<"0.0.1">>},0},
  {<<"multiaddr">>,{pkg,<<"multiaddr">>,<<"1.1.3">>},0},
@@ -8,7 +8,7 @@
 [
 {pkg_hash,[
  {<<"base32">>, <<"044F6DC95709727CA2176F3E97A41DDAA76B5BC690D3536908618C0CB32616A2">>},
- {<<"ecc_compact">>, <<"B2DDA47A6810B59A24331F3C864001A2FDE1C85A7BC31E52E7B6B2EE532F5627">>},
+ {<<"ecc_compact">>, <<"C9696FF16A1D721F2DC8CCD760440B8F45586522974C5C7BD88640822E08AACA">>},
  {<<"enacl">>, <<"F65DC64D9BFF2D8A534CB77AEF14DA5E7A2FA148987D87856F79A4745C9C2627">>},
  {<<"erl_base58">>, <<"37710854461D71DF338E73C65776302DB41C4BAB4674D2EC134ED7BCFC7B5552">>},
  {<<"multiaddr">>, <<"978E58E28F6FACAF428C87AF933612B1E2F3F2775F1794EDA5E831A4EACD2984">>},


### PR DESCRIPTION
The rust wallet ecc_compact file format uses the compact public key as the byte encoding instead of the full public key used in libp2p_crypto.

This fixes loading of compact rust wallet keys