### PR TITLE
Set rust toolchain in GHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Rust Toolchain
+        run: rustup default stable
+
       - name: Cache Hex Packages
         uses: actions/cache@v1
         with:


### PR DESCRIPTION
Note that is PR targets `xandkar/multisig`, not `main`. This patch should fix the GHA CI build.