### PR TITLE
Add support for secp256k1 (aka k-256) keys.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,16 @@
 
 This is a library of cryptography functions used by Helium's Erlang libp2p implementation.
 
-The library knows how to create and use two different types of key
-systems, [ecc_compact](https://hex.pm/packages/ecc_compact) and
-[ed25519](https://hex.pm/packages/enacl).
+The library knows how to create and use three different types of key
+systems:
 
-ecc_compact keys are used for addressing nodes in the system since
-there is hardware support for ECC operations, while ed25519 keys are
-used for user wallets since there are common browsed implementations
-for this kind of key.
+1. [ecc_compact](https://hex.pm/packages/ecc_compact),
+2. [ed25519](https://hex.pm/packages/enacl), and
+3. [secp256k1](https://www.secg.org/sec2-v2.pdf).
+
+ecc_compact keys are used for addressing hardware-constrained nodes in the
+system, while ed25519 and secp256k1 keys are used for user wallets since
+they are often managed by systems under less constraints.
 
 
 ## Using the library
@@ -34,12 +36,17 @@ Creating an ecc_compact keypair
 KeyMap = #{public := PubKey, secret := PrivKey} = libp2p_crypto:generate_keys(ecc_compact).
 ```
 
-And an ed25519 key:
+An ed25519 key:
 
 ```erlang
 KeyMap = #{public := PubKey, secret := PrivKey} = libp2p_crypto:generate_keys(ed25519).
 ```
 
+And a secp256k1 key:
+
+```erlang
+KeyMap = #{public := PubKey, secret := PrivKey} = libp2p_crypto:generate_keys(secp256k1).
+```
 
 ## Saving/Loading keys
 
@@ -47,7 +54,7 @@ Storing keypairs on disk should be considered very carefully from a
 security perspective since the resulting file will include both the
 public and private key.
 
-If the system supports hardware key storage use it instead of storing
+If the system supports hardware key storage, use it instead of storing
 secrets on disk. That said, many systems don't support hardware key
 storage so here is how to save keys:
 

--- a/eqc/multisig_eqc.erl
+++ b/eqc/multisig_eqc.erl
@@ -45,7 +45,7 @@ prop_multipubkey_test() ->
     ).
 
 gen_keytype() ->
-    elements([ecc_compact, ed25519]).
+    elements([ecc_compact, ed25519, secp256k1]).
 
 gen_m_n() ->
     ?SUCHTHAT({M, N}, {int(), int()}, (N > M andalso N =< 255 andalso M >= 1)).

--- a/rebar.config
+++ b/rebar.config
@@ -13,7 +13,7 @@
 
 {deps, [
     {multihash, "2.1.0"},
-    {ecc_compact, "1.0.5"},
+    {ecc_compact, {git, "git://github.com/helium/ecc_compact", {branch, "jsc/secp256k1"}}},
     {enacl, "1.1.1"},
     {erl_base58, "0.0.1"},
     {multiaddr, "1.1.3"}

--- a/rebar.config
+++ b/rebar.config
@@ -13,7 +13,7 @@
 
 {deps, [
     {multihash, "2.1.0"},
-    {ecc_compact, {git, "git://github.com/helium/ecc_compact", {branch, "jsc/secp256k1"}}},
+    {ecc_compact, "1.1.0"},
     {enacl, "1.1.1"},
     {erl_base58, "0.0.1"},
     {multiaddr, "1.1.3"}

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,9 +1,6 @@
 {"1.1.0",
 [{<<"base32">>,{pkg,<<"base32">>,<<"0.1.0">>},1},
- {<<"ecc_compact">>,
-  {git,"git://github.com/helium/ecc_compact",
-       {ref,"0410416782f75a0db91ec17110377e022faab1cd"}},
-  0},
+ {<<"ecc_compact">>,{pkg,<<"ecc_compact">>,<<"1.1.0">>},0},
  {<<"enacl">>,{pkg,<<"enacl">>,<<"1.1.1">>},0},
  {<<"erl_base58">>,{pkg,<<"erl_base58">>,<<"0.0.1">>},0},
  {<<"multiaddr">>,{pkg,<<"multiaddr">>,<<"1.1.3">>},0},
@@ -12,6 +9,7 @@
 [
 {pkg_hash,[
  {<<"base32">>, <<"044F6DC95709727CA2176F3E97A41DDAA76B5BC690D3536908618C0CB32616A2">>},
+ {<<"ecc_compact">>, <<"78CA96FD6C8CEF91990A4B1E243E6682DED46CEEAF1C0D154EA19A2A0679A239">>},
  {<<"enacl">>, <<"F65DC64D9BFF2D8A534CB77AEF14DA5E7A2FA148987D87856F79A4745C9C2627">>},
  {<<"erl_base58">>, <<"37710854461D71DF338E73C65776302DB41C4BAB4674D2EC134ED7BCFC7B5552">>},
  {<<"multiaddr">>, <<"978E58E28F6FACAF428C87AF933612B1E2F3F2775F1794EDA5E831A4EACD2984">>},

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,6 +1,9 @@
 {"1.1.0",
 [{<<"base32">>,{pkg,<<"base32">>,<<"0.1.0">>},1},
- {<<"ecc_compact">>,{pkg,<<"ecc_compact">>,<<"1.0.5">>},0},
+ {<<"ecc_compact">>,
+  {git,"git://github.com/helium/ecc_compact",
+       {ref,"0410416782f75a0db91ec17110377e022faab1cd"}},
+  0},
  {<<"enacl">>,{pkg,<<"enacl">>,<<"1.1.1">>},0},
  {<<"erl_base58">>,{pkg,<<"erl_base58">>,<<"0.0.1">>},0},
  {<<"multiaddr">>,{pkg,<<"multiaddr">>,<<"1.1.3">>},0},
@@ -9,7 +12,6 @@
 [
 {pkg_hash,[
  {<<"base32">>, <<"044F6DC95709727CA2176F3E97A41DDAA76B5BC690D3536908618C0CB32616A2">>},
- {<<"ecc_compact">>, <<"C9696FF16A1D721F2DC8CCD760440B8F45586522974C5C7BD88640822E08AACA">>},
  {<<"enacl">>, <<"F65DC64D9BFF2D8A534CB77AEF14DA5E7A2FA148987D87856F79A4745C9C2627">>},
  {<<"erl_base58">>, <<"37710854461D71DF338E73C65776302DB41C4BAB4674D2EC134ED7BCFC7B5552">>},
  {<<"multiaddr">>, <<"978E58E28F6FACAF428C87AF933612B1E2F3F2775F1794EDA5E831A4EACD2984">>},


### PR DESCRIPTION
Add support for ECC secp256k1, also known as SEC2 K-256 keys.

Also clean up and comment a bit more on the differences between
swarm key files produced by `helium-wallet-rs` and those produced
by this library to help ensure that these format differences will continue
to be easily differentiable by byte size, alone, into the foreseeable future.

Currently depends a private branch of `ecc_compact` for point
decompression.