### PR TITLE
truncate overlong signatures

### DIFF
--- a/src/libp2p_crypto.erl
+++ b/src/libp2p_crypto.erl
@@ -404,7 +404,8 @@ verify(Bin, MultiSignature, {multisig, M, N, KeysDigest}) ->
     verify_multisig(Bin, MultiSignature, {multisig, M, N, KeysDigest}, HashTypes);
 verify(Bin, Signature, {ecc_compact, PubKey}) ->
     public_key:verify(Bin, sha256, Signature, PubKey);
-verify(Bin, Signature, {ed25519, PubKey}) ->
+verify(Bin, Signature0, {ed25519, PubKey}) ->
+    Signature = binary:part(Signature0, min(64, byte_size(Signature0))),
     enacl:sign_verify_detached(Signature, Bin, PubKey).
 
 -spec verify_multisig(binary(), binary(), pubkey_multi(), [atom()]) -> boolean().

--- a/src/libp2p_crypto.erl
+++ b/src/libp2p_crypto.erl
@@ -405,7 +405,7 @@ verify(Bin, MultiSignature, {multisig, M, N, KeysDigest}) ->
 verify(Bin, Signature, {ecc_compact, PubKey}) ->
     public_key:verify(Bin, sha256, Signature, PubKey);
 verify(Bin, Signature0, {ed25519, PubKey}) ->
-    Signature = binary:part(Signature0, min(64, byte_size(Signature0))),
+    Signature = binary:part(Signature0, {0, min(64, byte_size(Signature0))}),
     enacl:sign_verify_detached(Signature, Bin, PubKey).
 
 -spec verify_multisig(binary(), binary(), pubkey_multi(), [atom()]) -> boolean().


### PR DESCRIPTION
While ideally we would not allow these at all, there are a few sigs the old chain where the first 64 bytes are a valid signature.  Newer versions of the enacl NIF check the size and no longer allow them, so we need to truncate them before they're tried.  After this merges, we likely should add a chain-var controlled validation step for signatures to restrict them to the proper size in all transactions.